### PR TITLE
🎨 Palette: Improve accessibility of icon-only navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-01 - Adding context to icon-only links
+**Learning:** Icon-only links without accessible names lack context for screen readers. In addition, missing clear visual focus states can make keyboard navigation difficult for users relying on non-mouse input.
+**Action:** Always add descriptive `aria-label` attributes to icon-only buttons/links, and explicitly style `focus-visible` states to ensure interaction patterns are clear to all users.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,10 +594,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a aria-label="GitHub Profile" href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 rounded-full p-1">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a aria-label="LinkedIn Profile" href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 rounded-full p-1">
                <Linkedin className="w-5 h-5" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
@@ -640,10 +640,10 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a aria-label="GitHub Profile" href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 rounded-full p-1">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a aria-label="LinkedIn Profile" href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 rounded-full p-1">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />


### PR DESCRIPTION
💡 **What:** Added `aria-label`s to the GitHub and LinkedIn icon-only links in the navigation (desktop and mobile) and provided clear `focus-visible` styling.

🎯 **Why:** Icon-only links without accessible names cannot be interpreted by screen readers. In addition, users who depend on keyboard navigation need clear visual cues of their focus location, which was previously missing for these links.

📸 **Before/After:** Verified focus states locally. Added a screenshot to confirm focus rings display effectively.

♿ **Accessibility:**
- Improved screen reader support with explicit labels ("GitHub Profile", "LinkedIn Profile").
- Improved keyboard navigation with explicit `focus-visible` highlighting.

---
*PR created automatically by Jules for task [7183829468681689459](https://jules.google.com/task/7183829468681689459) started by @meetshah1708*