### PR TITLE
🎨 Palette: Theme Toggle & Navigation Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-03 - [Missing Theme Toggle Context Update]
+**Learning:** The navigation menu previously lacked the theme toggler despite ThemeContext being fully configured and provided around the App, making the portfolio stuck in "light" theme with dark-coded classes or unable to be switched manually by users.
+**Action:** Added a `ThemeToggle` component to both desktop and mobile navigation bars to allow users to switch themes, improving UX. Added focus rings and ARIA labels for accessibility.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Github, Linkedin, Mail, FileText, Briefcase, ExternalLink, Download, Menu, X, ArrowRight, Sparkles, Code2, Zap, Rocket, Award, GraduationCap, Send, CheckCircle, AlertCircle, Loader2, Activity, BarChart3, Flame, TrendingUp } from 'lucide-react';
+import { Github, Linkedin, Mail, FileText, Briefcase, ExternalLink, Download, Menu, X, ArrowRight, Sparkles, Code2, Zap, Rocket, Award, GraduationCap, Send, CheckCircle, AlertCircle, Loader2, Activity, BarChart3, Flame, TrendingUp, Sun, Moon } from 'lucide-react';
 import { BrowserRouter as Router, Routes, Route, Link, NavLink } from 'react-router-dom';
-import { ThemeProvider} from './context/ThemeContext';
+import { ThemeProvider, useTheme } from './context/ThemeContext';
 import { motion, AnimatePresence, useScroll, useMotionValue, useSpring } from 'framer-motion';
 import { pageTransition, fadeInUp, staggerContainer, cardHover3D } from './utils/animations';
 import { useDebounce } from './utils/useDebounce';
@@ -513,6 +513,20 @@ const skillIcons: Record<string, string> = {
   NLP: "https://img.icons8.com/color/48/natural-language-processing.png"
 };
 
+const ThemeToggle = () => {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      className="text-slate-400 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 rounded-full p-1"
+    >
+      {theme === 'dark' ? <Moon className="w-5 h-5" /> : <Sun className="w-5 h-5" />}
+    </button>
+  );
+};
+
 const AppContent: React.FC = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = React.useState(false);
   const [scrolled, setScrolled] = React.useState(false);
@@ -594,13 +608,14 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 rounded-full p-1">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 rounded-full p-1">
                <Linkedin className="w-5 h-5" />
              </a>
-             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
+             <ThemeToggle />
+             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500">
                Let's Talk
              </Link>
           </div>
@@ -640,14 +655,15 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 rounded-full p-1">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 rounded-full p-1">
                      <Linkedin className="w-5 h-5" />
                    </a>
+                   <ThemeToggle />
                    <div className="flex-1" />
-                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center">
+                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500">
                      Hire Me
                    </Link>
                 </div>


### PR DESCRIPTION
🎨 Palette: Theme Toggle & Navigation Accessibility

💡 What: 
- Added a `ThemeToggle` component to the top navigation (desktop & mobile).
- Added `aria-label`s to the GitHub and LinkedIn icon-only buttons.
- Added `focus-visible` styling (`focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 rounded-full`) for keyboard navigation across all icon links.
- Created `.Jules/palette.md` to document the lack of Theme Context exposure.

🎯 Why: 
The `ThemeContext` was completely configured and provided throughout `App.tsx` but lacked any UI control for the user to switch it manually. This meant the app was effectively stuck in "light" theme unless the user's localStorage specified otherwise from a previous state. In addition, the icon-only links lacked text descriptions for screen readers and visible focus states for keyboard-only users.

♿ Accessibility:
- Added `aria-label`s so screen readers correctly announce the purpose of icon links.
- Added `focus-visible` outline rings to support users tabbing through the navigation.
- Added ARIA label to ThemeToggle describing its action based on current state.

---
*PR created automatically by Jules for task [13498239204375154696](https://jules.google.com/task/13498239204375154696) started by @meetshah1708*