### PR TITLE
🎨 Palette: [Accessibility] Improve icon-only links and mobile menu toggle

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-20 - Accessible Icon-Only Navigation & Mobile Menus
+**Learning:** Icon-only navigation links (like GitHub/LinkedIn) and dynamic mobile menu buttons often lack proper accessibility context for screen readers and visible focus states for keyboard users.
+**Action:** Always add `aria-label` and `title` (for tooltips) to icon-only buttons/links. For interactive toggles like mobile menus, include dynamic `aria-expanded` and `aria-controls` attributes. Use `focus-visible` classes with robust rings (`focus-visible:ring-2`, `focus-visible:ring-offset-2` if needed) to ensure keyboard navigability is visually apparent.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,10 +594,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:rounded" aria-label="GitHub Profile" title="GitHub Profile">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:rounded" aria-label="LinkedIn Profile" title="LinkedIn Profile">
                <Linkedin className="w-5 h-5" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
@@ -606,9 +606,12 @@ const AppContent: React.FC = () => {
           </div>
 
           <button
-            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
+            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
             onClick={toggleMobileMenu}
-            aria-label="Toggle mobile menu"
+            aria-label={isMobileMenuOpen ? "Close mobile menu" : "Open mobile menu"}
+            title={isMobileMenuOpen ? "Close mobile menu" : "Open mobile menu"}
+            aria-expanded={isMobileMenuOpen}
+            aria-controls="mobile-menu-list"
           >
             {isMobileMenuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
           </button>
@@ -617,6 +620,7 @@ const AppContent: React.FC = () => {
           <AnimatePresence>
             {isMobileMenuOpen && (
               <motion.div
+                id="mobile-menu-list"
                 initial={{ opacity: 0, height: 0, y: -10 }}
                 animate={{ opacity: 1, height: "auto", y: 0 }}
                 exit={{ opacity: 0, height: 0, y: -10 }}
@@ -629,7 +633,7 @@ const AppContent: React.FC = () => {
                     to={item.to}
                     onClick={closeMobileMenu}
                     className={({ isActive }) =>
-                      `px-4 py-3 rounded-xl text-sm font-medium transition-all duration-300 ${
+                      `px-4 py-3 rounded-xl text-sm font-medium transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-inset ${
                         isActive
                           ? 'bg-white/10 border border-white/10 text-white'
                           : 'bg-transparent border border-transparent text-slate-400 hover:bg-white/5 hover:text-white'
@@ -640,10 +644,10 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:rounded" aria-label="GitHub Profile" title="GitHub Profile">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:rounded" aria-label="LinkedIn Profile" title="LinkedIn Profile">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />


### PR DESCRIPTION
🎨 Palette: [Accessibility] Improve icon-only links and mobile menu toggle

💡 What: Added accessible names (aria-label, title) and keyboard focus styles (focus-visible rings) to icon-only navigation links. Upgraded the mobile menu toggle to use dynamic accessible labels and correct ARIA states (aria-expanded, aria-controls).
🎯 Why: Screen reader users and keyboard navigators previously lacked context and visual cues for these essential navigation elements.
♿ Accessibility:
  - Added aria-label and title to icon-only links.
  - Added focus-visible styles to these links.
  - Added dynamic aria-label, aria-expanded, and aria-controls to the mobile menu toggle button.

---
*PR created automatically by Jules for task [11142733862235853903](https://jules.google.com/task/11142733862235853903) started by @meetshah1708*