### PR TITLE
🎨 Palette: Add ARIA labels and focus states to social links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Navigation Link Accessibility
+**Learning:** Icon-only navigation links frequently lack proper aria-labels and keyboard focus indicators. Adding them provides immediate and significant accessibility benefits without disrupting visual layout.
+**Action:** When inspecting navigation components, specifically look for anchor tags wrapping icons without explicit aria-labels, and verify their `focus-visible` states using Tailwind `ring` classes.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,10 +594,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub profile" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 rounded-sm">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 rounded-sm">
                <Linkedin className="w-5 h-5" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
@@ -640,10 +640,10 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 rounded-sm">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 rounded-sm">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />


### PR DESCRIPTION
💡 What: Added `aria-label` attributes ("GitHub profile", "LinkedIn profile") and `focus-visible` styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 rounded-sm`) to the icon-only social links in the top navigation bar (both desktop and mobile views).
🎯 Why: Icon-only links without accessible names are invisible to screen readers, and lacking focus indicators makes keyboard navigation difficult. This small change ensures all users can identify and access these important links.
📸 Before/After: Visual appearance is unchanged until focused via keyboard. (See generated screenshot for focus state verification).
♿ Accessibility: Improves WCAG compliance for Name, Role, Value (4.1.2) and Focus Visible (2.4.7).

---
*PR created automatically by Jules for task [8421403564041767235](https://jules.google.com/task/8421403564041767235) started by @meetshah1708*