### PR TITLE
🎨 Palette: Add ARIA labels and focus styles to icon-only navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2023-11-09 - Adding Accessibility to Icon-Only Links
+**Learning:** Icon-only links often lack sufficient context for screen reader users, and missing focus states make keyboard navigation difficult.
+**Action:** Add `aria-label` attributes to provide context, `aria-hidden="true"` to hide decorative icons, and explicitly define focus rings (e.g., `focus-visible:ring-2`) on the parent link/button to ensure keyboard accessibility.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,23 +594,24 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
-               <Github className="w-5 h-5" />
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 rounded-full transition-colors">
+               <Github className="w-5 h-5" aria-hidden="true" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
-               <Linkedin className="w-5 h-5" />
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 rounded-full transition-colors">
+               <Linkedin className="w-5 h-5" aria-hidden="true" />
              </a>
-             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
+             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400">
                Let's Talk
              </Link>
           </div>
 
           <button
-            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
+            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
             onClick={toggleMobileMenu}
             aria-label="Toggle mobile menu"
+            aria-expanded={isMobileMenuOpen}
           >
-            {isMobileMenuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+            {isMobileMenuOpen ? <X className="w-5 h-5" aria-hidden="true" /> : <Menu className="w-5 h-5" aria-hidden="true" />}
           </button>
 
           {/* Mobile Menu Slide-down within the floating bar */}
@@ -640,14 +641,14 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
-                     <Github className="w-5 h-5" />
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 rounded-full">
+                     <Github className="w-5 h-5" aria-hidden="true" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
-                     <Linkedin className="w-5 h-5" />
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 rounded-full">
+                     <Linkedin className="w-5 h-5" aria-hidden="true" />
                    </a>
                    <div className="flex-1" />
-                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center">
+                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400">
                      Hire Me
                    </Link>
                 </div>


### PR DESCRIPTION
## 💡 What
Added `aria-label`s and keyboard focus states to the icon-only navigation links (GitHub and LinkedIn) and the mobile menu toggle button. Also hid the raw SVG tags from screen readers.

## 🎯 Why
Icon-only links often lack sufficient context for screen reader users, making it unclear what the link's destination is. In addition, the lack of explicit keyboard focus states makes navigating the primary navigation bar difficult for users who rely on keyboard navigation.

## ♿ Accessibility
- Added descriptive `aria-label` attributes to anchor links.
- Added `aria-hidden="true"` to decorative SVGs.
- Added `aria-expanded` tracking to the mobile menu button.
- Added explicit `focus-visible:ring-2` to provide visual feedback for keyboard users navigating the header.
- Logged this pattern in `.Jules/palette.md` to ensure it is standardized.

---
*PR created automatically by Jules for task [8592079385215765793](https://jules.google.com/task/8592079385215765793) started by @meetshah1708*