### PR TITLE
🎨 Palette: Add ARIA labels to social links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - ARIA labels for icon-only external links
+**Learning:** Icon-only anchor links representing social media links are missing ARIA labels or visually hidden text, which causes accessibility issues as screen readers won't know the destination.
+**Action:** Add `aria-label` to anchor tags that only contain an icon, especially those linking to external sites like GitHub and LinkedIn, to ensure they are accessible.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,10 +594,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white transition-colors">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white transition-colors">
                <Linkedin className="w-5 h-5" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
@@ -640,10 +640,10 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to the GitHub and LinkedIn anchor tags in both the desktop and mobile navigation menus in `src/App.tsx`. Added a new journal entry to `.Jules/palette.md` noting the importance of ensuring icon-only external links have screen reader accessible labels.

🎯 **Why**: The icon-only links lacked text content, which means screen readers would have difficulty identifying their purpose to users. This small change enhances the accessibility (a11y) of the app by ensuring the navigation is inclusive.

📸 **Before/After**: Visually, the change is non-destructive and doesn't affect the layout. Verified via local Playwright screenshot.

♿ **Accessibility**:
- Screen readers will now correctly announce "GitHub Profile" and "LinkedIn Profile" instead of an uninformative URL or link text.

---
*PR created automatically by Jules for task [15121975791361142989](https://jules.google.com/task/15121975791361142989) started by @meetshah1708*