### PR TITLE
🎨 Palette: Add ARIA labels and focus states to navigation icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Added keyboard accessibility to navigation icons
+**Learning:** Icon-only navigation links (GitHub, LinkedIn) in the top nav and mobile menu were missing ARIA labels and focus states, making them difficult for keyboard and screen reader users to access.
+**Action:** Always add explicit `aria-label`s to icon-only links, and include `focus-visible` states to improve keyboard navigation visibility.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,10 +594,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white focus-visible:text-white focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:outline-none rounded-sm transition-colors">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white focus-visible:text-white focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:outline-none rounded-sm transition-colors">
                <Linkedin className="w-5 h-5" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
@@ -606,7 +606,7 @@ const AppContent: React.FC = () => {
           </div>
 
           <button
-            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
+            className="md:hidden relative z-10 text-slate-300 hover:text-white focus-visible:text-white focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:outline-none transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
             onClick={toggleMobileMenu}
             aria-label="Toggle mobile menu"
           >
@@ -640,10 +640,10 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white focus-visible:text-white focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:outline-none rounded-sm transition-colors">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white focus-visible:text-white focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:outline-none rounded-sm transition-colors">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />


### PR DESCRIPTION
**💡 What:** Added explicit `aria-label` attributes to the GitHub and LinkedIn icon-only links in both the desktop and mobile navigation. Also added `focus-visible` utility classes to these links and the mobile menu toggle button. Additionally, created a `.Jules/palette.md` journal entry to record this learning.

**🎯 Why:** Icon-only navigation links without descriptive labels are inaccessible to screen reader users, who rely on text alternatives to understand link destinations. Furthermore, interactive elements must have clear visual focus indicators so keyboard users can track their navigation path across the UI. This enhances the site's overall accessibility and usability.

**📸 Before/After:** See the attached screenshot for the new visual focus ring state on the GitHub link.

**♿ Accessibility:**
* Added semantic `aria-label`s to social links for screen reader support.
* Improved keyboard navigation by adding high-contrast, visually distinct focus rings (`focus-visible:ring-2 focus-visible:ring-sky-400`).

---
*PR created automatically by Jules for task [4468868857933639372](https://jules.google.com/task/4468868857933639372) started by @meetshah1708*