### PR TITLE
🎨 Palette: Enhance accessibility of navigation icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-05 - Navigation Icon Accessibility & Focus States
+**Learning:** Icon-only navigation links (like GitHub/LinkedIn in global nav) often lack accessible names for screen readers and lack distinct keyboard focus states, making navigation difficult for visually impaired or keyboard-only users.
+**Action:** When adding icon-only links or buttons, always include an `aria-label` (and optionally a `title` for hover tooltip), set `aria-hidden="true"` on the SVG/icon component itself to avoid redundant/confusing announcements, and ensure distinct `focus-visible` styles are applied for keyboard navigation. Additionally, toggle buttons should use `aria-expanded` and dynamic labels based on their state.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,11 +594,11 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
-               <Github className="w-5 h-5" />
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile" className="text-slate-400 hover:text-white transition-colors focus-visible:ring-2 focus-visible:ring-sky-500 rounded-full outline-none">
+               <Github className="w-5 h-5" aria-hidden="true" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
-               <Linkedin className="w-5 h-5" />
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile" className="text-slate-400 hover:text-white transition-colors focus-visible:ring-2 focus-visible:ring-sky-500 rounded-full outline-none">
+               <Linkedin className="w-5 h-5" aria-hidden="true" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
                Let's Talk
@@ -606,9 +606,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <button
-            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
+            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center focus-visible:ring-2 focus-visible:ring-sky-500 outline-none"
             onClick={toggleMobileMenu}
-            aria-label="Toggle mobile menu"
+            aria-label={isMobileMenuOpen ? "Close mobile menu" : "Open mobile menu"}
+            aria-expanded={isMobileMenuOpen}
           >
             {isMobileMenuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
           </button>
@@ -640,11 +641,11 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
-                     <Github className="w-5 h-5" />
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" title="GitHub Profile" className="text-slate-400 hover:text-white focus-visible:ring-2 focus-visible:ring-sky-500 rounded-full outline-none">
+                     <Github className="w-5 h-5" aria-hidden="true" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
-                     <Linkedin className="w-5 h-5" />
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" title="LinkedIn Profile" className="text-slate-400 hover:text-white focus-visible:ring-2 focus-visible:ring-sky-500 rounded-full outline-none">
+                     <Linkedin className="w-5 h-5" aria-hidden="true" />
                    </a>
                    <div className="flex-1" />
                    <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center">
@@ -1115,7 +1116,7 @@ const LandingPage: React.FC = () => {
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 px-8 py-4 rounded-full border border-white/20 bg-white/5 text-white/90 font-semibold hover:bg-white/10"
             >
-              <Linkedin className="w-5 h-5" />
+              <Linkedin className="w-5 h-5" aria-hidden="true" />
               <span>LinkedIn</span>
             </a>
             <a
@@ -1124,7 +1125,7 @@ const LandingPage: React.FC = () => {
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 px-8 py-4 rounded-full border border-white/20 bg-white/5 text-white/90 font-semibold hover:bg-white/10"
             >
-              <Github className="w-5 h-5" />
+              <Github className="w-5 h-5" aria-hidden="true" />
               <span>GitHub</span>
             </a>
           </div>


### PR DESCRIPTION
### 💡 What
Added accessible names (`aria-label`, `title`) and clear keyboard focus states (`focus-visible:ring-2`) to icon-only navigation links and buttons. Added `aria-hidden` to the SVGs, and dynamic `aria-expanded` to the mobile menu toggle.

### 🎯 Why
Icon-only links without accessible names are invisible to screen reader users, and missing focus states make keyboard navigation difficult.

### 📸 Before/After
See attached verification screenshots showing the new focus ring around the GitHub navigation link and the mobile menu toggle.

### ♿ Accessibility
- Added `aria-label` to give screen readers context for icon-only links.
- Added `focus-visible` styles to show a clear ring when tabbing through navigation.
- Added `aria-hidden="true"` to the SVG elements to prevent duplicate announcements.
- Improved mobile menu toggle with `aria-expanded` state communication.

---
*PR created automatically by Jules for task [18269077769053757204](https://jules.google.com/task/18269077769053757204) started by @meetshah1708*