### PR TITLE
🎨 Palette: Add ARIA labels to social media links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,10 +594,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub profile" className="text-slate-400 hover:text-white transition-colors">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile" className="text-slate-400 hover:text-white transition-colors">
                <Linkedin className="w-5 h-5" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
@@ -640,10 +640,10 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub profile" className="text-slate-400 hover:text-white">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile" className="text-slate-400 hover:text-white">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to the GitHub and LinkedIn icon-only links in both the desktop and mobile navigation menus.

🎯 **Why:** Icon-only links lack text context, making them opaque to screen readers. Adding `aria-label` attributes ensures these links are fully accessible.

📸 **Before/After:** No visual changes. 

♿ **Accessibility:** Added descriptive accessible names to icon-only links, ensuring they are properly announced by screen readers.

---
*PR created automatically by Jules for task [6897184129983744643](https://jules.google.com/task/6897184129983744643) started by @meetshah1708*