### PR TITLE
🎨 Palette: Add ARIA labels to icon-only social links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-06-10 - Missing ARIA Labels on Icon-only Social Links
+**Learning:** Icon-only anchor links used for social profiles (like GitHub and LinkedIn) within navigation headers and mobile menus frequently lack screen-reader-accessible text. Without `aria-label`s, screen readers might just announce "link" or read the raw URL, leading to poor accessibility.
+**Action:** Always verify that components consisting solely of SVG icons (like lucide-react icons inside `<a>` or `<button>` tags) include an explicit `aria-label` or visually hidden text to communicate their purpose to assistive technologies.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,10 +594,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white transition-colors">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white transition-colors">
                <Linkedin className="w-5 h-5" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
@@ -640,10 +640,10 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />


### PR DESCRIPTION
💡 What: Added `aria-label`s ("GitHub Profile" and "LinkedIn Profile") to the icon-only anchor links in the main navigation and mobile menu.
🎯 Why: Without these labels, screen readers announce the links vaguely (e.g., just "link" or reading the raw URL), which degrades the experience for users relying on assistive technologies.
📸 Before/After: Visuals are unchanged. The changes only affect screen reader announcements.
♿ Accessibility: Improves accessibility by explicitly stating the destination of the GitHub and LinkedIn icon buttons for screen readers.

---
*PR created automatically by Jules for task [7385875066350785577](https://jules.google.com/task/7385875066350785577) started by @meetshah1708*