### PR TITLE
🎨 Palette: Add ARIA labels to icon-only social links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,10 +594,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white transition-colors">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white transition-colors">
                <Linkedin className="w-5 h-5" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
@@ -640,10 +640,10 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to the GitHub and LinkedIn icon-only links in both the desktop navigation bar and the mobile dropdown menu.

🎯 **Why:** To improve accessibility. Previously, these anchor tags only contained SVG icons, meaning screen readers would read out confusing text (like the URL itself) or simply announce "link" without providing context about the destination. The new `aria-label` ("GitHub Profile", "LinkedIn Profile") provides a clear, descriptive name for assistive technologies.

📸 **Before/After:** No visual changes since the attributes are hidden to sighted users, but a verification screenshot confirms the UI is completely visually unchanged.

♿ **Accessibility:**
- Added `aria-label="GitHub Profile"` to the GitHub `<a>` links.
- Added `aria-label="LinkedIn Profile"` to the LinkedIn `<a>` links.
- Ensured these changes are present on both desktop and mobile view navigations.

---
*PR created automatically by Jules for task [15762826127676115640](https://jules.google.com/task/15762826127676115640) started by @meetshah1708*