### PR TITLE
🎨 Palette: Add explicit ARIA labels to social media links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-13 - Add ARIA Labels to Social Links
+**Learning:** Found social links (GitHub, LinkedIn) in the navigation header that use icon-only content without accessible names, causing screen readers to announce generic link elements rather than the specific destination.
+**Action:** Adding explicit `aria-label` attributes to these icon-only anchor tags (`<a href="..." aria-label="GitHub Profile">`) ensures screen reader users understand the link's purpose.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,10 +594,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white transition-colors">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white transition-colors">
                <Linkedin className="w-5 h-5" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
@@ -640,10 +640,10 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />


### PR DESCRIPTION
**💡 What:** Added `aria-label` attributes to the icon-only GitHub and LinkedIn links in the navigation bar and mobile menu.
**🎯 Why:** Screen reader users will now hear a descriptive accessible name ("GitHub Profile", "LinkedIn Profile") instead of a generic or uninformative link text when navigating to these links.
**📸 Before/After:** No visual changes since it's an accessibility enhancement.
**♿ Accessibility:** Enhances screen reader accessibility for icon-only links.

---
*PR created automatically by Jules for task [8712765755830499612](https://jules.google.com/task/8712765755830499612) started by @meetshah1708*