### PR TITLE
🎨 Palette: Improve keyboard accessibility for navigation links and menu button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,10 +594,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white transition-colors focus-visible:ring-2 focus-visible:ring-sky-400 focus:outline-none rounded-md">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white transition-colors focus-visible:ring-2 focus-visible:ring-sky-400 focus:outline-none rounded-md">
                <Linkedin className="w-5 h-5" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
@@ -606,7 +606,7 @@ const AppContent: React.FC = () => {
           </div>
 
           <button
-            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
+            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center focus-visible:ring-2 focus-visible:ring-sky-400 focus:outline-none"
             onClick={toggleMobileMenu}
             aria-label="Toggle mobile menu"
           >
@@ -640,10 +640,10 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white focus-visible:ring-2 focus-visible:ring-sky-400 focus:outline-none rounded-md">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white focus-visible:ring-2 focus-visible:ring-sky-400 focus:outline-none rounded-md">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes to the GitHub and LinkedIn icon-only links in both the desktop and mobile navigation bars. Added `focus-visible` styling (`focus-visible:ring-2 focus-visible:ring-sky-400 focus:outline-none`) to these links as well as the mobile menu toggle button.

### 🎯 Why
Icon-only links without accessible names cannot be interpreted by screen readers, making the navigation confusing for visually impaired users. Furthermore, interactive elements lacked clear focus states, making keyboard navigation difficult to track. These micro-UX enhancements address both issues natively using existing Tailwind CSS classes.

### 📸 Before/After
*(Verified visually via Playwright script traversing the UI elements using `Tab` key presses, confirming the new focus rings appear correctly. Reference verification screenshot.)*

### ♿ Accessibility
* Screen readers will now announce "GitHub Profile" and "LinkedIn Profile" instead of generic URLs.
* Keyboard-only users can clearly see which interactive element in the navigation is currently focused via a cyan focus ring, following WCAG Focus Visible guidelines.

---
*PR created automatically by Jules for task [10758070669336223687](https://jules.google.com/task/10758070669336223687) started by @meetshah1708*