### PR TITLE
🎨 Palette: Add keyboard focus indicators and ARIA labels to navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## $(date +%Y-%m-%d) - Focus Ring Design System Pattern
+**Learning:** The established design system pattern for keyboard focus indicators on interactive elements in this app utilizes a specific combination of Tailwind classes to match the dark theme and cyan accents: `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2`.
+**Action:** When adding focus states to future interactive elements, consistently apply these classes. Adjust the `ring-offset` color (e.g., `focus-visible:ring-offset-[#030712]`) and `border-radius` (e.g., `rounded-full` or `rounded-lg`) to match the surrounding context.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -572,7 +572,7 @@ const AppContent: React.FC = () => {
                 key={item.to}
                 to={item.to}
                 className={({ isActive }) =>
-                  `relative px-5 py-2 text-sm font-medium transition-all duration-300 ${
+                  `relative px-5 py-2 text-sm font-medium transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full ${
                     isActive ? 'text-white' : 'text-slate-400 hover:text-white'
                   }`
                 }
@@ -594,20 +594,21 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a aria-label="GitHub profile" href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a aria-label="LinkedIn profile" href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1">
                <Linkedin className="w-5 h-5" />
              </a>
-             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
+             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">
                Let's Talk
              </Link>
           </div>
 
           <button
-            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
+            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]"
             onClick={toggleMobileMenu}
+            aria-expanded={isMobileMenuOpen}
             aria-label="Toggle mobile menu"
           >
             {isMobileMenuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
@@ -629,7 +630,7 @@ const AppContent: React.FC = () => {
                     to={item.to}
                     onClick={closeMobileMenu}
                     className={({ isActive }) =>
-                      `px-4 py-3 rounded-xl text-sm font-medium transition-all duration-300 ${
+                      `px-4 py-3 rounded-xl text-sm font-medium transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 ${
                         isActive
                           ? 'bg-white/10 border border-white/10 text-white'
                           : 'bg-transparent border border-transparent text-slate-400 hover:bg-white/5 hover:text-white'
@@ -640,14 +641,14 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a aria-label="GitHub profile" href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 rounded-full p-1">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a aria-label="LinkedIn profile" href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 rounded-full p-1">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />
-                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center">
+                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400">
                      Hire Me
                    </Link>
                 </div>


### PR DESCRIPTION
💡 What:
- Added explicit `aria-label` attributes to the GitHub and LinkedIn icon-only links.
- Added `aria-expanded` state tracking to the mobile menu toggle button.
- Implemented comprehensive `focus-visible` styling (`focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2`) on all interactive navigation elements.

🎯 Why:
To ensure the application remains fully accessible to keyboard users by providing a clear, stylized focus indicator that matches the design system, and to ensure screen reader users have clear context for icon-only buttons.

♿ Accessibility:
- Addresses WCAG 2.4.7 (Focus Visible)
- Addresses WCAG 4.1.2 (Name, Role, Value) by assigning accessible names to social links.

📸 Screenshots verified via Playwright integration in local tests.

---
*PR created automatically by Jules for task [3451458221138924405](https://jules.google.com/task/3451458221138924405) started by @meetshah1708*