### PR TITLE
🎨 Palette: Add accessible focus states and ARIA labels to navigation icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-23 - Added accessible focus states and ARIA labels to navigation icons
+**Learning:** Icon-only social links (GitHub, LinkedIn) in the navigation bar lacked ARIA labels for screen reader support and keyboard focus indicators for accessible navigation.
+**Action:** When adding or auditing icon-only interactive elements, ensure they have descriptive `aria-label`s. Always apply the design system's established focus pattern (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]`) to provide clear visual feedback for keyboard users. Use `rounded-full` or adjust `ring-offset` styling to match the element's shape and context.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,10 +594,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full">
                <Linkedin className="w-5 h-5" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
@@ -606,7 +606,7 @@ const AppContent: React.FC = () => {
           </div>
 
           <button
-            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
+            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]"
             onClick={toggleMobileMenu}
             aria-label="Toggle mobile menu"
           >
@@ -640,10 +640,10 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />


### PR DESCRIPTION
## 🎨 Palette: Navigation Accessibility Polish

### 💡 What
Added `aria-label` attributes to the GitHub and LinkedIn icon links in the navigation bar. Also introduced keyboard focus indicators (`focus-visible` states) to these links and the mobile menu toggle button using existing Tailwind CSS utilities. Additionally, updated the Palette journal with a new learning regarding interactive icon accessibility.

### 🎯 Why
- **Screen Reader Support:** Icon-only buttons without accessible names are announced as "link" or "button" by screen readers, providing no context. The `aria-label` attribute resolves this by providing a programmatic name.
- **Keyboard Navigation:** Users navigating via keyboard (using the Tab key) rely on visible focus indicators to know which element is currently active. The default browser outlines are often inconsistent or insufficient. Adding prominent focus rings improves usability and complies with WCAG standards for focus visibility.

### 📸 Before/After

*The change is purely interactive and attribute-based, no default visual state has been modified. The screenshot demonstrates the new focus state when navigating via keyboard.*

**After (Focus State on GitHub Icon):**
![Focus State Screenshot](/home/jules/verification/screenshots/verification_github_focus.png)

### ♿ Accessibility
- Fixed missing accessible names on social links.
- Implemented high-contrast, visible focus rings using the site's design tokens to aid keyboard navigation.

---
*PR created automatically by Jules for task [5950677490719263858](https://jules.google.com/task/5950677490719263858) started by @meetshah1708*