### PR TITLE
🎨 Palette: Add ARIA labels and focus states to navigation elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-23 - Custom Keyboard Focus Pattern for Tailwind
+**Learning:** Tailwind's default outline style can be difficult to see on dark themes or complex backgrounds. Creating a reusable custom focus pattern using `ring` classes improves visibility significantly.
+**Action:** Use the pattern `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[theme-color] focus-visible:ring-offset-2 focus-visible:ring-offset-[background-color]` to ensure interactive elements are clearly accessible to keyboard users across the design system. Adjust border-radius (e.g. `rounded-full`) to match the component context.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,19 +594,19 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1">
                <Linkedin className="w-5 h-5" />
              </a>
-             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
+             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">
                Let's Talk
              </Link>
           </div>
 
           <button
-            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
+            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]"
             onClick={toggleMobileMenu}
             aria-label="Toggle mobile menu"
           >
@@ -640,14 +640,14 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />
-                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center">
+                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">
                      Hire Me
                    </Link>
                 </div>


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes to icon-only social links and implemented clear keyboard focus indicators for all interactive navigation elements using Tailwind utility classes.

### 🎯 Why
To vastly improve the accessibility of the site navigation. Without ARIA labels, screen reader users wouldn't know the purpose of the GitHub/LinkedIn icons. Without visible focus indicators, keyboard-only users would be unable to tell which navigation element they are currently interacting with.

### 📸 Before/After
*(Screenshots will be uploaded here from local verification)*

### ♿ Accessibility
- Screen readers now correctly announce "GitHub Profile" and "LinkedIn Profile" instead of generic button content.
- Keyboard navigation users now see a clear, high-contrast cyan focus ring around active links, making tab navigation fluid and obvious.

---
*PR created automatically by Jules for task [5235156670412995452](https://jules.google.com/task/5235156670412995452) started by @meetshah1708*