### PR TITLE
🎨 Palette: Add ARIA labels and visible focus rings to navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-24 - Focus Rings on Icon Links
+**Learning:** Icon-only links and buttons frequently lack ARIA labels and keyboard focus indicators. The standard design system pattern for focus rings is `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2` with an appropriate `ring-offset` color (e.g. `focus-visible:ring-offset-[#030712]`) and `border-radius`.
+**Action:** Always verify keyboard accessibility by ensuring interactive elements have focus indicators correctly matching the background offset color.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,19 +594,19 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub profile" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1">
                <Linkedin className="w-5 h-5" />
              </a>
-             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
+             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">
                Let's Talk
              </Link>
           </div>
 
           <button
-            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
+            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]"
             onClick={toggleMobileMenu}
             aria-label="Toggle mobile menu"
           >
@@ -640,14 +640,14 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />
-                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center">
+                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">
                      Hire Me
                    </Link>
                 </div>


### PR DESCRIPTION
* 💡 **What**: Added `aria-label` attributes to icon-only social links and implemented standard keyboard focus ring styles (`focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2`) on all navigation interactive elements.
* 🎯 **Why**: Screen readers previously couldn't announce the purpose of the GitHub/LinkedIn icons. Keyboard users could not easily see which element had focus when tabbing through the navigation menu.
* 📸 **Before/After**: Verified via Playwright screenshot. Focus state is now clearly visible.
* ♿ **Accessibility**: Resolves WCAG 4.1.2 (Name, Role, Value) by adding `aria-label`s, and WCAG 2.4.7 (Focus Visible) by providing explicit focus indicators for keyboard navigation.

---
*PR created automatically by Jules for task [16376438370968776283](https://jules.google.com/task/16376438370968776283) started by @meetshah1708*