### PR TITLE
🎨 Palette: Add ARIA labels and focus styles to icon-only links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-26 - Missing ARIA labels on social links
+**Learning:** Icon-only navigation links (like GitHub and LinkedIn in header and mobile menu) often lack `aria-label`s, causing screen readers to read out the raw URL or nothing at all, breaking accessibility.
+**Action:** Always ensure `aria-label` attributes are present on anchor tags (`<a>`) and `<button>`s that only contain SVG icons for visual representation.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,19 +594,19 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full">
                <Linkedin className="w-5 h-5" />
              </a>
-             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
+             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">
                Let's Talk
              </Link>
           </div>
 
           <button
-            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
+            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]"
             onClick={toggleMobileMenu}
             aria-label="Toggle mobile menu"
           >
@@ -640,14 +640,14 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />
-                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center">
+                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">
                      Hire Me
                    </Link>
                 </div>


### PR DESCRIPTION
**💡 What:** 
Added missing `aria-label` attributes and keyboard focus-visible styling (Tailwind CSS ring utilities) to the icon-only social links (GitHub, LinkedIn) in the main header and mobile menu, as well as the mobile menu toggle button.

**🎯 Why:**
Icon-only links without accessible names result in screen readers reading the raw URL, which is confusing and poor UX. Keyboard users navigating via the Tab key need clear visual indicators of which element is currently focused.

**📸 Before/After:**
*Before:* Clicking 'Tab' through the top header showed no visual focus indication for the social icons. Screen readers had no descriptive text for them.
*After:* (See attached verification screenshot) Navigating via 'Tab' now shows a clear, contextual cyan focus ring around the icons. 

**♿ Accessibility:**
- Added `aria-label` attributes so screen readers will announce "GitHub Profile" and "LinkedIn Profile".
- Added visible focus indicators conforming to WCAG 2.4.7 Focus Visible requirements, styling the focus outline to match the application's dark aesthetic (`ring-offset-[#030712]`).

---
*PR created automatically by Jules for task [5568993347941249552](https://jules.google.com/task/5568993347941249552) started by @meetshah1708*