### PR TITLE
🎨 Palette: Improve accessibility of header icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing ARIA labels and Focus indicators on Icon-only Header Elements
+**Learning:** In the navigation header, icon-only social links and the mobile menu toggle button were missing both accessible names (`aria-label`) and clear keyboard focus indicators, making them functionally invisible to screen readers and difficult for keyboard-only users to navigate.
+**Action:** Applied `aria-label`s and standard design system focus rings (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]`) to all icon-only interactive elements in the header layout.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,10 +594,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1" aria-label="GitHub Profile">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1" aria-label="LinkedIn Profile">
                <Linkedin className="w-5 h-5" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
@@ -606,7 +606,7 @@ const AppContent: React.FC = () => {
           </div>
 
           <button
-            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
+            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]"
             onClick={toggleMobileMenu}
             aria-label="Toggle mobile menu"
           >
@@ -640,10 +640,10 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1" aria-label="GitHub Profile">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full p-1" aria-label="LinkedIn Profile">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />


### PR DESCRIPTION
💡 **What:** Added accessible names (`aria-label`) and standard design-system keyboard focus indicators (`focus-visible`) to all icon-only interactive elements in the navigation header (social links and mobile menu toggle).

🎯 **Why:** Icon-only buttons are invisible to screen readers without an `aria-label`, and keyboard-only users cannot easily tell when these elements are focused if they lack a clear focus ring. This makes the header navigation fully accessible.

♿ **Accessibility:**
- Ensures screen readers announce the purpose of the GitHub, LinkedIn, and Mobile Menu toggle buttons.
- Improves WCAG 2.1 Success Criterion 2.4.7 (Focus Visible) compliance.

📸 **Before/After:** Visually verified locally via Playwright that focus rings render correctly when tabbing through the header links.

---
*PR created automatically by Jules for task [2278610232966891609](https://jules.google.com/task/2278610232966891609) started by @meetshah1708*