### PR TITLE
🎨 Palette: Add ARIA labels and focus states to navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - Focus States and ARIA Labels on Icon Links
+**Learning:** Icon-only navigation links (like GitHub and LinkedIn) often miss critical ARIA labels, making them inaccessible to screen readers. Furthermore, a cohesive design system should apply visible keyboard focus indicators consistently, using a matching background offset color (like `#030712`) when dealing with dark themed apps.
+**Action:** When auditing navigation menus, always ensure that `aria-label` attributes are added to purely icon-based links and that they have visible `focus-visible` styles with a ring-offset color matching the surrounding context.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -594,19 +594,19 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white transition-colors p-1 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white transition-colors p-1 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">
                <Linkedin className="w-5 h-5" />
              </a>
-             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
+             <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">
                Let's Talk
              </Link>
           </div>
 
           <button
-            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
+            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]"
             onClick={toggleMobileMenu}
             aria-label="Toggle mobile menu"
           >
@@ -640,14 +640,14 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="text-slate-400 hover:text-white p-1 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="text-slate-400 hover:text-white p-1 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />
-                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center">
+                   <Link to="/contact" onClick={closeMobileMenu} className="bg-white text-black px-4 py-1.5 rounded-full text-sm font-bold text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">
                      Hire Me
                    </Link>
                 </div>
@@ -1135,9 +1135,9 @@ const LandingPage: React.FC = () => {
         <div className="max-w-6xl mx-auto px-6 flex flex-col sm:flex-row justify-between items-center gap-3 text-sm text-white/40">
           <p>© 2026 Meet Shah. Crafted with React, Framer Motion, and Three.js.</p>
           <div className="flex items-center gap-5">
-            <a href="https://github.com/meet1785" target="_blank" rel="noopener noreferrer" className="hover:text-white/70 transition-colors">GitHub</a>
-            <a href="https://linkedin.com/in/meetshah1708" target="_blank" rel="noopener noreferrer" className="hover:text-white/70 transition-colors">LinkedIn</a>
-            <a href="mailto:meetshah1785@gmail.com" className="hover:text-white/70 transition-colors">Email</a>
+            <a href="https://github.com/meet1785" target="_blank" rel="noopener noreferrer" className="hover:text-white/70 transition-colors px-2 py-1 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">GitHub</a>
+            <a href="https://linkedin.com/in/meetshah1708" target="_blank" rel="noopener noreferrer" className="hover:text-white/70 transition-colors px-2 py-1 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">LinkedIn</a>
+            <a href="mailto:meetshah1785@gmail.com" className="hover:text-white/70 transition-colors px-2 py-1 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]">Email</a>
           </div>
         </div>
       </footer>


### PR DESCRIPTION
💡 **What:** 
Added `aria-label` attributes to icon-only navigation links (GitHub and LinkedIn) and implemented consistent, highly visible keyboard focus rings (`focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]`) to all interactive elements within the navigation bar, including the mobile menu toggle and "Let's Talk" / "Hire Me" call-to-action buttons.

🎯 **Why:** 
Icon-only links without accessible names are invisible to screen readers, leaving users guessing their purpose. Furthermore, keyboard-only users rely on clear, visible focus indicators to know which element they are currently interacting with. A consistent focus ring that respects the dark-mode aesthetic ensures users can navigate smoothly without losing track of their position on the page.

📸 **Before/After:**
*(See PR screenshots for before/after visual focus state changes. Previously, tabbing through the navigation menu yielded little to no visual feedback. Now, a clear cyan ring highlights the currently focused element.)*

♿ **Accessibility:** 
- **Screen Reader Support:** Icon-only links now have descriptive `aria-label`s.
- **Keyboard Navigation:** Added highly visible focus indicators to interactive elements, meeting WCAG focus visibility standards and improving usability for keyboard navigation.

---
*PR created automatically by Jules for task [8317381236693866273](https://jules.google.com/task/8317381236693866273) started by @meetshah1708*