### PR TITLE
🎨 Palette: Improve keyboard accessibility and ARIA labels for navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Navigation Icon Accessibility
+**Learning:** Icon-only navigation links (like social icons and brand logos) require explicit `aria-label`s for screen readers and `focus-visible` styles with appropriate ring-offsets for keyboard navigation visibility.
+**Action:** Always verify icon-only links have both `aria-label` and `focus-visible` classes (e.g., `focus-visible:ring-cyan-400 focus-visible:ring-offset-[#030712] rounded-full`).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -556,7 +556,7 @@ const AppContent: React.FC = () => {
           animate={{ y: 0, opacity: 1 }}
           transition={{ duration: 0.8, ease: [0.16, 1, 0.3, 1] }}
         >
-          <Link to="/" className="group flex items-center gap-2 md:mr-4 z-10" onClick={closeMobileMenu}>
+          <Link to="/" className="group flex items-center gap-2 md:mr-4 z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full" onClick={closeMobileMenu} aria-label="Home">
             <div className="relative flex items-center justify-center w-8 h-8 rounded-full bg-gradient-to-tr from-cyan-500 to-blue-500 text-white font-bold text-xs overflow-hidden">
                <span className="relative z-10">MS</span>
                <div className="absolute inset-0 bg-white/20 opacity-0 group-hover:opacity-100 transition-opacity" />
@@ -594,10 +594,10 @@ const AppContent: React.FC = () => {
           </div>
 
           <div className="hidden md:flex items-center gap-3 z-10 ml-4">
-             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full" aria-label="GitHub Profile">
                <Github className="w-5 h-5" />
              </a>
-             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors">
+             <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full" aria-label="LinkedIn Profile">
                <Linkedin className="w-5 h-5" />
              </a>
              <Link to="/contact" className="ml-2 bg-white text-black hover:bg-cyan-400 hover:text-black hover:shadow-[0_0_20px_rgba(34,211,238,0.4)] px-5 py-2 rounded-full text-sm font-bold transition-all duration-300 transform hover:scale-105">
@@ -606,7 +606,7 @@ const AppContent: React.FC = () => {
           </div>
 
           <button
-            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center"
+            className="md:hidden relative z-10 text-slate-300 hover:text-white transition-colors w-10 h-10 rounded-full bg-white/5 border border-white/10 flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]"
             onClick={toggleMobileMenu}
             aria-label="Toggle mobile menu"
           >
@@ -640,10 +640,10 @@ const AppContent: React.FC = () => {
                   </NavLink>
                 ))}
                 <div className="flex items-center gap-4 px-4 py-3 mt-2 mb-1 border-t border-white/10">
-                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.github} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full" aria-label="GitHub Profile">
                      <Github className="w-5 h-5" />
                    </a>
-                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white">
+                   <a href={DATA.personalInfo.linkedin} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] rounded-full" aria-label="LinkedIn Profile">
                      <Linkedin className="w-5 h-5" />
                    </a>
                    <div className="flex-1" />


### PR DESCRIPTION
**💡 What:**
Added explicit `aria-label` attributes and highly visible keyboard focus states (`focus-visible`) to all icon-only navigation elements (Brand logo, Desktop & Mobile GitHub/LinkedIn links, and the Mobile Menu toggle button).

**🎯 Why:**
Keyboard users and screen reader users need clear indications of where they are on the page. Icon-only links without `aria-label`s are often read opaquely by screen readers (e.g., just "link"), and without explicit focus states, keyboard users cannot track their navigation path through the interactive elements.

**📸 Before/After:**
*(Screenshots captured during Frontend Verification show the clear cyan focus ring around the brand logo and social icons when navigating via `Tab`)*

**♿ Accessibility:**
- Improved screen reader context for all core navigation elements via `aria-label`.
- Greatly enhanced keyboard navigation visibility by implementing explicit Tailwind `focus-visible` styles with appropriate ring-offsets.

---
*PR created automatically by Jules for task [12776976290747061114](https://jules.google.com/task/12776976290747061114) started by @meetshah1708*