### PR TITLE
🎨 Palette: Improve Contact Form Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
+## 2025-07-06 - Accessible Form Validation
+**Learning:** When using form validation libraries like React Hook Form, visually showing an error is not enough for screen readers. The error message must be explicitly connected to the input.
+**Action:** Always use `aria-invalid={!!errors.field}` and `aria-describedby="field-error"` on the input, and add `id="field-error"` to the error message paragraph.
 ## 2025-03-08 - Added keyboard focus styles and ARIA labels
 **Learning:** Many interactive elements lacked clear focus states for keyboard users, and icon-only buttons lacked ARIA labels. Using Tailwind's \`focus-visible\` ensures these styles only appear during keyboard navigation, maintaining aesthetics for mouse users while improving accessibility.
 **Action:** Always add \`focus-visible:ring-2\` (and associated classes) and \`aria-label\` to custom interactive elements.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2186,11 +2186,14 @@ const ContactPage: React.FC = () => {
                   {...register('name')}
                   type="text"
                   id="name"
+                  autoComplete="name"
+                  aria-invalid={!!errors.name}
+                  aria-describedby={errors.name ? "name-error" : undefined}
                   className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all"
                   placeholder="Your full name"
                 />
                 {errors.name && (
-                  <p className="mt-1 text-sm text-red-400 flex items-center gap-1">
+                  <p id="name-error" className="mt-1 text-sm text-red-400 flex items-center gap-1">
                     <AlertCircle className="w-4 h-4" />
                     {errors.name.message}
                   </p>
@@ -2205,11 +2208,14 @@ const ContactPage: React.FC = () => {
                   {...register('email')}
                   type="email"
                   id="email"
+                  autoComplete="email"
+                  aria-invalid={!!errors.email}
+                  aria-describedby={errors.email ? "email-error" : undefined}
                   className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all"
                   placeholder="your.email@example.com"
                 />
                 {errors.email && (
-                  <p className="mt-1 text-sm text-red-400 flex items-center gap-1">
+                  <p id="email-error" className="mt-1 text-sm text-red-400 flex items-center gap-1">
                     <AlertCircle className="w-4 h-4" />
                     {errors.email.message}
                   </p>
@@ -2224,11 +2230,13 @@ const ContactPage: React.FC = () => {
                   {...register('subject')}
                   type="text"
                   id="subject"
+                  aria-invalid={!!errors.subject}
+                  aria-describedby={errors.subject ? "subject-error" : undefined}
                   className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all"
                   placeholder="What's this about?"
                 />
                 {errors.subject && (
-                  <p className="mt-1 text-sm text-red-400 flex items-center gap-1">
+                  <p id="subject-error" className="mt-1 text-sm text-red-400 flex items-center gap-1">
                     <AlertCircle className="w-4 h-4" />
                     {errors.subject.message}
                   </p>
@@ -2243,11 +2251,13 @@ const ContactPage: React.FC = () => {
                   {...register('message')}
                   id="message"
                   rows={6}
+                  aria-invalid={!!errors.message}
+                  aria-describedby={errors.message ? "message-error" : undefined}
                   className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all resize-none"
                   placeholder="Tell me about your project or opportunity..."
                 />
                 {errors.message && (
-                  <p className="mt-1 text-sm text-red-400 flex items-center gap-1">
+                  <p id="message-error" className="mt-1 text-sm text-red-400 flex items-center gap-1">
                     <AlertCircle className="w-4 h-4" />
                     {errors.message.message}
                   </p>


### PR DESCRIPTION
💡 What: Added `aria-invalid`, `aria-describedby`, and `autoComplete` attributes to the contact form fields. Added corresponding `id` attributes to the error messages.
🎯 Why: To explicitly connect error messages with input fields for screen readers. Previously, validation errors were only indicated visually, leaving screen reader users without proper context when a field failed validation. Added autocomplete for general usability.
📸 Before/After: Screenshots were verified during the frontend testing phase.
♿ Accessibility: Screen readers will now announce validation errors when focusing on the respective invalid input fields.

---
*PR created automatically by Jules for task [5179094468509323851](https://jules.google.com/task/5179094468509323851) started by @meetshah1708*