### PR TITLE
🎨 Palette: Add focus-visible states to custom interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-03-08 - Added keyboard focus styles and ARIA labels
 **Learning:** Many interactive elements lacked clear focus states for keyboard users, and icon-only buttons lacked ARIA labels. Using Tailwind's \`focus-visible\` ensures these styles only appear during keyboard navigation, maintaining aesthetics for mouse users while improving accessibility.
 **Action:** Always add \`focus-visible:ring-2\` (and associated classes) and \`aria-label\` to custom interactive elements.
+## 2025-03-08 - Adding Focus Outlines to Interactive Elements
+**Learning:** Some custom `<button>`, `<input>`, and `<Link>` components in the application lack explicit focus outlines for keyboard navigation, specifically custom-styled form inputs and interactive journey buttons. Standard Tailwind `focus:outline-none` was used without providing a `focus-visible` alternative, hurting accessibility.
+**Action:** Always ensure that custom interactive elements replace `focus:outline-none` with `focus-visible:ring-2` (and `focus-visible:outline-none`) to provide clear visual feedback to keyboard users without disturbing mouse users.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2186,7 +2186,7 @@ const ContactPage: React.FC = () => {
                   {...register('name')}
                   type="text"
                   id="name"
-                  className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all"
+                  className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:border-transparent focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] transition-all"
                   placeholder="Your full name"
                 />
                 {errors.name && (
@@ -2205,7 +2205,7 @@ const ContactPage: React.FC = () => {
                   {...register('email')}
                   type="email"
                   id="email"
-                  className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all"
+                  className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:border-transparent focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] transition-all"
                   placeholder="your.email@example.com"
                 />
                 {errors.email && (
@@ -2224,7 +2224,7 @@ const ContactPage: React.FC = () => {
                   {...register('subject')}
                   type="text"
                   id="subject"
-                  className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all"
+                  className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:border-transparent focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] transition-all"
                   placeholder="What's this about?"
                 />
                 {errors.subject && (
@@ -2243,7 +2243,7 @@ const ContactPage: React.FC = () => {
                   {...register('message')}
                   id="message"
                   rows={6}
-                  className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all resize-none"
+                  className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:border-transparent focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] transition-all resize-none"
                   placeholder="Tell me about your project or opportunity..."
                 />
                 {errors.message && (
@@ -2257,7 +2257,7 @@ const ContactPage: React.FC = () => {
               <button
                 type="submit"
                 disabled={isSubmitting}
-                className="w-full inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-sky-500 to-blue-600 text-white font-semibold rounded-xl shadow-lg shadow-sky-500/25 hover:shadow-sky-500/40 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300"
+                className="w-full inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-sky-500 to-blue-600 text-white font-semibold rounded-xl shadow-lg shadow-sky-500/25 hover:shadow-sky-500/40 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]"
               >
                 {isSubmitting ? (
                   <>

--- a/src/components/AssetMotionSection.tsx
+++ b/src/components/AssetMotionSection.tsx
@@ -183,7 +183,7 @@ export const AssetMotionSection: React.FC = () => {
 
             <Link
               to="/works"
-              className="inline-flex items-center gap-2 px-5 py-3 rounded-full border border-sky-400/30 text-sky-200 hover:text-white hover:bg-sky-500/10 hover:border-sky-300/50 transition-all duration-300 text-sm font-medium"
+              className="inline-flex items-center gap-2 px-5 py-3 rounded-full border border-sky-400/30 text-sky-200 hover:text-white hover:bg-sky-500/10 hover:border-sky-300/50 transition-all duration-300 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
             >
               <span>Preview with projects</span>
               <ArrowRight className="w-4 h-4" />

--- a/src/components/scene/CarJourneyLanding.tsx
+++ b/src/components/scene/CarJourneyLanding.tsx
@@ -176,7 +176,7 @@ const JourneyScene = ({ onStationChange, onProgressChange }) => {
              <input type="text" placeholder="Incoming Designation (Name)" className="bg-slate-900 border border-cyan-800 p-4 text-cyan-100 rounded focus:border-magenta-400 outline-none transition-colors" />
              <input type="email" placeholder="Frequency (Email)" className="bg-slate-900 border border-cyan-800 p-4 text-cyan-100 rounded focus:border-magenta-400 outline-none transition-colors" />
              <textarea placeholder="Message payload..." className="bg-slate-900 border border-cyan-800 p-4 h-32 resize-none text-cyan-100 rounded focus:border-magenta-400 outline-none transition-colors"></textarea>
-             <button type="button" className="bg-magenta-600 hover:bg-magenta-500 py-4 font-bold text-white tracking-[0.2em] rounded uppercase mt-2">Transmit</button>
+             <button type="button" className="bg-magenta-600 hover:bg-magenta-500 py-4 font-bold text-white tracking-[0.2em] rounded uppercase mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-magenta-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black">Transmit</button>
            </form>
            <div className="flex justify-center gap-6 mt-6">
              <a href={DATA.personalInfo.github} className="text-cyan-400 hover:text-white transition-colors">GITHUB</a>

--- a/src/components/scene/CyberpunkJourney.tsx
+++ b/src/components/scene/CyberpunkJourney.tsx
@@ -233,7 +233,7 @@ export const CarJourneyLanding = () => {
         <h2 className="text-3xl font-bold text-orange-400 tracking-wide">ABOUT & WORK</h2>
       </div>
       <p className="text-base opacity-80 mb-6 leading-relaxed">Discover my professional journey and experiences architecting scalable systems across various companies.</p>
-      <button onClick={() => handleNavigate('/about')} className="bg-gradient-to-r from-orange-600 to-orange-500 hover:from-orange-500 hover:to-orange-400 text-white font-bold py-3 px-6 rounded-xl transition-all shadow-lg hover:shadow-orange-500/30 w-full uppercase tracking-widest text-sm cursor-pointer pointer-events-auto flex justify-center items-center gap-2">
+      <button onClick={() => handleNavigate('/about')} className="bg-gradient-to-r from-orange-600 to-orange-500 hover:from-orange-500 hover:to-orange-400 text-white font-bold py-3 px-6 rounded-xl transition-all shadow-lg hover:shadow-orange-500/30 w-full uppercase tracking-widest text-sm cursor-pointer pointer-events-auto flex justify-center items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black">
          Explore Work History
          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m9 18 6-6-6-6"/></svg>
       </button>
@@ -248,7 +248,7 @@ export const CarJourneyLanding = () => {
         <h2 className="text-3xl font-bold text-violet-400 tracking-wide">PROJECTS</h2>
       </div>
       <p className="text-base opacity-80 mb-6 leading-relaxed">A showcase of the sophisticated systems, high-traffic apps, and optimized platforms I have engineered.</p>
-      <button onClick={() => handleNavigate('/projects')} className="bg-gradient-to-r from-violet-600 to-violet-500 hover:from-violet-500 hover:to-violet-400 text-white font-bold py-3 px-6 rounded-xl transition-all shadow-lg hover:shadow-violet-500/30 w-full uppercase tracking-widest text-sm cursor-pointer pointer-events-auto flex justify-center items-center gap-2">
+      <button onClick={() => handleNavigate('/projects')} className="bg-gradient-to-r from-violet-600 to-violet-500 hover:from-violet-500 hover:to-violet-400 text-white font-bold py-3 px-6 rounded-xl transition-all shadow-lg hover:shadow-violet-500/30 w-full uppercase tracking-widest text-sm cursor-pointer pointer-events-auto flex justify-center items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black">
          View Portfolio
          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m9 18 6-6-6-6"/></svg>
       </button>
@@ -263,7 +263,7 @@ export const CarJourneyLanding = () => {
         <h2 className="text-3xl font-bold text-emerald-400 tracking-wide">SKILLS & ARCHIVE</h2>
       </div>
        <p className="text-base opacity-80 mb-6 leading-relaxed">Dive deeper into my technical stack containing React, TypeScript, Node.js, and access my verified resume.</p>
-       <button onClick={() => handleNavigate('/resume')} className="bg-gradient-to-r from-emerald-600 to-emerald-500 hover:from-emerald-500 hover:to-emerald-400 text-white font-bold py-3 px-6 rounded-xl transition-all shadow-lg hover:shadow-emerald-500/30 w-full uppercase tracking-widest text-sm cursor-pointer pointer-events-auto flex justify-center items-center gap-2">
+       <button onClick={() => handleNavigate('/resume')} className="bg-gradient-to-r from-emerald-600 to-emerald-500 hover:from-emerald-500 hover:to-emerald-400 text-white font-bold py-3 px-6 rounded-xl transition-all shadow-lg hover:shadow-emerald-500/30 w-full uppercase tracking-widest text-sm cursor-pointer pointer-events-auto flex justify-center items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black">
           Access Databank
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m9 18 6-6-6-6"/></svg>
        </button>
@@ -278,7 +278,7 @@ export const CarJourneyLanding = () => {
        </div>
        <h2 className="text-3xl text-white font-bold text-center mb-2 tracking-wide uppercase">Initiate Uplink</h2>
        <p className="text-sm opacity-70 mb-8 text-center leading-relaxed">Establish a secure connection for collaborations, freelance inquiries, or network handshakes.</p>
-       <button onClick={() => handleNavigate('/contact')} className="bg-magenta-600 hover:bg-magenta-500 text-white font-bold py-4 px-6 rounded-xl transition-all shadow-lg hover:shadow-magenta-500/40 w-full uppercase tracking-[0.2em] text-sm cursor-pointer pointer-events-auto filter drop-shadow">
+       <button onClick={() => handleNavigate('/contact')} className="bg-magenta-600 hover:bg-magenta-500 text-white font-bold py-4 px-6 rounded-xl transition-all shadow-lg hover:shadow-magenta-500/40 w-full uppercase tracking-[0.2em] text-sm cursor-pointer pointer-events-auto filter drop-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-magenta-400 focus-visible:ring-offset-2 focus-visible:ring-offset-black">
            Connect
        </button>
     </div>

--- a/src/components/scene/NexusCommandCenter.tsx
+++ b/src/components/scene/NexusCommandCenter.tsx
@@ -549,7 +549,7 @@ export const NexusCommandCenter: React.FC<NexusCommandCenterProps> = ({ displaye
                   key={item.key}
                   type="button"
                   onClick={() => setFocus(item.key)}
-                  className={`rounded-xl border px-3 py-3 text-sm transition-all duration-300 flex flex-col items-center gap-1 ${
+                  className={`rounded-xl border px-3 py-3 text-sm transition-all duration-300 flex flex-col items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
                     focus === item.key
                       ? 'border-cyan-200/45 bg-cyan-400/14 text-cyan-100'
                       : 'border-white/12 bg-white/[0.03] text-white/70 hover:text-white hover:bg-white/[0.06]'


### PR DESCRIPTION
💡 What: Added Tailwind `focus-visible` ring styles to custom buttons, inputs, and links across the application scenes and landing pages.
🎯 Why: To improve keyboard accessibility by providing clear visual focus indicators, making the site navigable for screen reader and keyboard-only users without compromising mouse hover aesthetics.
📸 Before/After: Interactive elements now display a themed focus outline when navigated via `Tab`.
♿ Accessibility: Replaced broad `focus:outline-none` styles with `focus-visible` aware rings to maintain visible focus states.

---
*PR created automatically by Jules for task [16983905790721898450](https://jules.google.com/task/16983905790721898450) started by @meetshah1708*