### PR TITLE
🎨 Palette: Add keyboard focus indicators to interactive buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-03-08 - Added keyboard focus styles and ARIA labels
 **Learning:** Many interactive elements lacked clear focus states for keyboard users, and icon-only buttons lacked ARIA labels. Using Tailwind's \`focus-visible\` ensures these styles only appear during keyboard navigation, maintaining aesthetics for mouse users while improving accessibility.
 **Action:** Always add \`focus-visible:ring-2\` (and associated classes) and \`aria-label\` to custom interactive elements.
+## 2025-02-21 - Custom components missing focus indicators
+**Learning:** Framer Motion components (`<motion.button>`) and custom styled components often lose their default browser focus indicators, especially when complex Tailwind classes (like gradients or background clips) are applied. Users relying on keyboard navigation (Tab) get lost as there is no visual cue of which element is focused.
+**Action:** Explicitly add Tailwind's `focus-visible` utility classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2`) to all interactive elements, matching the ring color and offset to the surrounding UI.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1310,7 +1310,7 @@ const WorksPage: React.FC = () => {
                 whileHover={{ scale: 1.05, y: -2 }}
                 whileTap={{ scale: 0.95 }}
                 onClick={() => handleFilterChange(tech)}
-                className={`relative px-4 py-2 rounded-full font-medium text-sm transition-all duration-300 font-body overflow-hidden ${
+                className={`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] relative px-4 py-2 rounded-full font-medium text-sm transition-all duration-300 font-body overflow-hidden ${
                   selectedFilter === tech
                     ? 'bg-gradient-to-r from-sky-500 to-blue-600 text-white shadow-lg shadow-sky-500/25'
                     : 'bg-white/5 text-white/60 hover:bg-white/10 hover:text-white border border-white/10 hover:border-white/20'
@@ -1436,7 +1436,7 @@ const ResumePage: React.FC = () => {
               }}
               whileHover={{ scale: 1.05, y: -2 }}
               whileTap={{ scale: 0.95 }}
-              className="inline-flex items-center space-x-3 px-8 py-4 bg-gradient-to-r from-red-500 to-pink-600 text-white font-semibold rounded-xl shadow-lg shadow-red-500/25 hover:shadow-red-500/40 transition-all duration-300 cta-shine"
+              className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] inline-flex items-center space-x-3 px-8 py-4 bg-gradient-to-r from-red-500 to-pink-600 text-white font-semibold rounded-xl shadow-lg shadow-red-500/25 hover:shadow-red-500/40 transition-all duration-300 cta-shine"
             >
               <Download className="w-5 h-5" />
               <span>Download PDF</span>
@@ -1449,7 +1449,7 @@ const ResumePage: React.FC = () => {
               }}
               whileHover={{ scale: 1.05, y: -2 }}
               whileTap={{ scale: 0.95 }}
-              className="inline-flex items-center space-x-3 px-8 py-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white font-semibold rounded-xl shadow-lg shadow-blue-500/25 hover:shadow-blue-500/40 transition-all duration-300 cta-shine"
+              className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] inline-flex items-center space-x-3 px-8 py-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white font-semibold rounded-xl shadow-lg shadow-blue-500/25 hover:shadow-blue-500/40 transition-all duration-300 cta-shine"
             >
               <Download className="w-5 h-5" />
               <span>Download DOCX</span>
@@ -2257,7 +2257,7 @@ const ContactPage: React.FC = () => {
               <button
                 type="submit"
                 disabled={isSubmitting}
-                className="w-full inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-sky-500 to-blue-600 text-white font-semibold rounded-xl shadow-lg shadow-sky-500/25 hover:shadow-sky-500/40 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300"
+                className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712] w-full inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-r from-sky-500 to-blue-600 text-white font-semibold rounded-xl shadow-lg shadow-sky-500/25 hover:shadow-sky-500/40 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-300"
               >
                 {isSubmitting ? (
                   <>


### PR DESCRIPTION
### 💡 What
Added standard Tailwind `focus-visible` styling (`focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#030712]`) to interactive buttons that were previously missing them, including:
- The technology filter buttons on the Works page
- The PDF and DOCX download buttons on the Resume page
- The Submit button on the Contact form

### 🎯 Why
Custom-styled components (like buttons with gradients or Framer Motion properties) often lose their default browser focus rings. This makes it impossible for users relying on keyboard navigation (e.g., using the `Tab` key) to know which element is currently focused, severely degrading accessibility.

### 📸 Before/After
*(Screenshots were generated during verification to confirm focus rings appear correctly during tabbing without affecting the mouse hover states.)*

### ♿ Accessibility
- Dramatically improves keyboard navigation by providing clear, high-contrast visual focus indicators for interactive elements.
- Ensures WCAG compliance for Focus Visible (2.4.7) and Non-text Contrast (1.4.11).

---
*PR created automatically by Jules for task [10337817787045893572](https://jules.google.com/task/10337817787045893572) started by @meetshah1708*