### PR TITLE
🎨 Palette: Improve Form Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-03-08 - Added keyboard focus styles and ARIA labels
 **Learning:** Many interactive elements lacked clear focus states for keyboard users, and icon-only buttons lacked ARIA labels. Using Tailwind's \`focus-visible\` ensures these styles only appear during keyboard navigation, maintaining aesthetics for mouse users while improving accessibility.
 **Action:** Always add \`focus-visible:ring-2\` (and associated classes) and \`aria-label\` to custom interactive elements.
+
+## 2025-03-08 - Accessible Form Validation
+**Learning:** React Hook Form fields lacked accessibility attributes for their validation errors. Screen readers wouldn't announce errors when an input became invalid or link the error text to the input.
+**Action:** Always add \`aria-invalid={errors.fieldName ? "true" : "false"}\` and \`aria-describedby={errors.fieldName ? "fieldName-error" : undefined}\` to inputs, and \`id="fieldName-error"\` and \`role="alert"\` to the corresponding error message elements.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2186,11 +2186,13 @@ const ContactPage: React.FC = () => {
                   {...register('name')}
                   type="text"
                   id="name"
+                  aria-invalid={errors.name ? "true" : "false"}
+                  aria-describedby={errors.name ? "name-error" : undefined}
                   className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all"
                   placeholder="Your full name"
                 />
                 {errors.name && (
-                  <p className="mt-1 text-sm text-red-400 flex items-center gap-1">
+                  <p id="name-error" role="alert" className="mt-1 text-sm text-red-400 flex items-center gap-1">
                     <AlertCircle className="w-4 h-4" />
                     {errors.name.message}
                   </p>
@@ -2205,11 +2207,13 @@ const ContactPage: React.FC = () => {
                   {...register('email')}
                   type="email"
                   id="email"
+                  aria-invalid={errors.email ? "true" : "false"}
+                  aria-describedby={errors.email ? "email-error" : undefined}
                   className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all"
                   placeholder="your.email@example.com"
                 />
                 {errors.email && (
-                  <p className="mt-1 text-sm text-red-400 flex items-center gap-1">
+                  <p id="email-error" role="alert" className="mt-1 text-sm text-red-400 flex items-center gap-1">
                     <AlertCircle className="w-4 h-4" />
                     {errors.email.message}
                   </p>
@@ -2224,11 +2228,13 @@ const ContactPage: React.FC = () => {
                   {...register('subject')}
                   type="text"
                   id="subject"
+                  aria-invalid={errors.subject ? "true" : "false"}
+                  aria-describedby={errors.subject ? "subject-error" : undefined}
                   className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all"
                   placeholder="What's this about?"
                 />
                 {errors.subject && (
-                  <p className="mt-1 text-sm text-red-400 flex items-center gap-1">
+                  <p id="subject-error" role="alert" className="mt-1 text-sm text-red-400 flex items-center gap-1">
                     <AlertCircle className="w-4 h-4" />
                     {errors.subject.message}
                   </p>
@@ -2243,11 +2249,13 @@ const ContactPage: React.FC = () => {
                   {...register('message')}
                   id="message"
                   rows={6}
+                  aria-invalid={errors.message ? "true" : "false"}
+                  aria-describedby={errors.message ? "message-error" : undefined}
                   className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all resize-none"
                   placeholder="Tell me about your project or opportunity..."
                 />
                 {errors.message && (
-                  <p className="mt-1 text-sm text-red-400 flex items-center gap-1">
+                  <p id="message-error" role="alert" className="mt-1 text-sm text-red-400 flex items-center gap-1">
                     <AlertCircle className="w-4 h-4" />
                     {errors.message.message}
                   </p>


### PR DESCRIPTION
**💡 What:** Added proper ARIA attributes to the contact form validation messages.
**🎯 Why:** Screen reader users needed clear indication when a field was invalid and to be able to read the error message associated with the invalid field.
**📸 Before/After:** N/A (Non-visual change).
**♿ Accessibility:** Added `aria-invalid` and `aria-describedby` to the input fields and `id` and `role="alert"` to the error messages, making the form fully accessible.

---
*PR created automatically by Jules for task [12763911686774223708](https://jules.google.com/task/12763911686774223708) started by @meetshah1708*