### PR TITLE
🎨 Palette: Explicit ARIA ties for form validation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-03-08 - Added keyboard focus styles and ARIA labels
 **Learning:** Many interactive elements lacked clear focus states for keyboard users, and icon-only buttons lacked ARIA labels. Using Tailwind's \`focus-visible\` ensures these styles only appear during keyboard navigation, maintaining aesthetics for mouse users while improving accessibility.
 **Action:** Always add \`focus-visible:ring-2\` (and associated classes) and \`aria-label\` to custom interactive elements.
+
+## 2025-03-08 - Accessible Form Validation
+**Learning:** Forms using validation (like React Hook Form) need explicit ARIA ties between inputs and error messages to be accessible. Screen readers won't announce the error message text automatically unless linked.
+**Action:** Dynamically set \`aria-invalid={!!errors.field}\` and link the error message element using \`aria-describedby="field-error"\`, while ensuring the error message has \`role="alert"\` and \`id="field-error"\`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2186,11 +2186,13 @@ const ContactPage: React.FC = () => {
                   {...register('name')}
                   type="text"
                   id="name"
+                  aria-invalid={!!errors.name}
+                  aria-describedby={errors.name ? "name-error" : undefined}
                   className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all"
                   placeholder="Your full name"
                 />
                 {errors.name && (
-                  <p className="mt-1 text-sm text-red-400 flex items-center gap-1">
+                  <p id="name-error" role="alert" className="mt-1 text-sm text-red-400 flex items-center gap-1">
                     <AlertCircle className="w-4 h-4" />
                     {errors.name.message}
                   </p>
@@ -2205,11 +2207,13 @@ const ContactPage: React.FC = () => {
                   {...register('email')}
                   type="email"
                   id="email"
+                  aria-invalid={!!errors.email}
+                  aria-describedby={errors.email ? "email-error" : undefined}
                   className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all"
                   placeholder="your.email@example.com"
                 />
                 {errors.email && (
-                  <p className="mt-1 text-sm text-red-400 flex items-center gap-1">
+                  <p id="email-error" role="alert" className="mt-1 text-sm text-red-400 flex items-center gap-1">
                     <AlertCircle className="w-4 h-4" />
                     {errors.email.message}
                   </p>
@@ -2224,11 +2228,13 @@ const ContactPage: React.FC = () => {
                   {...register('subject')}
                   type="text"
                   id="subject"
+                  aria-invalid={!!errors.subject}
+                  aria-describedby={errors.subject ? "subject-error" : undefined}
                   className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all"
                   placeholder="What's this about?"
                 />
                 {errors.subject && (
-                  <p className="mt-1 text-sm text-red-400 flex items-center gap-1">
+                  <p id="subject-error" role="alert" className="mt-1 text-sm text-red-400 flex items-center gap-1">
                     <AlertCircle className="w-4 h-4" />
                     {errors.subject.message}
                   </p>
@@ -2243,11 +2249,13 @@ const ContactPage: React.FC = () => {
                   {...register('message')}
                   id="message"
                   rows={6}
+                  aria-invalid={!!errors.message}
+                  aria-describedby={errors.message ? "message-error" : undefined}
                   className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/20 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all resize-none"
                   placeholder="Tell me about your project or opportunity..."
                 />
                 {errors.message && (
-                  <p className="mt-1 text-sm text-red-400 flex items-center gap-1">
+                  <p id="message-error" role="alert" className="mt-1 text-sm text-red-400 flex items-center gap-1">
                     <AlertCircle className="w-4 h-4" />
                     {errors.message.message}
                   </p>


### PR DESCRIPTION
### 💡 What
Added `aria-invalid`, `aria-describedby`, and explicit matching error IDs with `role="alert"` to the inputs and error text within the `ContactPage` component.

### 🎯 Why
When form validation errors occur, assistive technologies (like screen readers) need to explicitly know which input is invalid, and they need to be able to immediately announce the correct error message associated with that input field. The previous setup relied purely on visual proximity.

### 📸 Before/After
*(Visuals remain identical for sighted users - screenshots attached in PR comments to prove zero visual regression)*

### ♿ Accessibility
- Added `aria-invalid` to inputs dynamically when their corresponding error exists in React Hook Form state.
- Added `aria-describedby` to inputs which point to new `id="[field]-error"` paragraphs.
- Added `role="alert"` to error text paragraphs to ensure the error text is announced as soon as it appears on the screen.

---
*PR created automatically by Jules for task [17282032955301439662](https://jules.google.com/task/17282032955301439662) started by @meetshah1708*